### PR TITLE
Response Message with Retrieved Rules, and other small dev/build details

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: pytest
+        entry: pytest -m "not integration"
         language: system
         types: [ python ]
         pass_filenames: false  # or use with: require_serial

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ RUN mkdir src
 COPY ./src/icehockey_rules ./src/icehockey_rules
 RUN pip install --no-cache-dir -e .
 
-COPY ./*.py ./
-
 COPY ./data/iihf-qa.yaml ./data/iihf-qa.yaml
 
 COPY ./config/config.yaml ./config/config.yaml

--- a/src/icehockey_rules/__init__.py
+++ b/src/icehockey_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 from pathlib import Path
 

--- a/src/icehockey_rules/pipelines.py
+++ b/src/icehockey_rules/pipelines.py
@@ -1,3 +1,5 @@
+import json
+
 from icehockey_rules.chat import query_to_retrieved_rules_and_rag_prompt, SYSTEM_PROMPT
 from icehockey_rules.retrieve import openai_client
 
@@ -27,4 +29,6 @@ def one_off_question_answer(
         ],
         temperature=llm_temperature,
     )
-    return completion.choices[0].message
+    message = completion.choices[0].message
+    message.rule_matches_df = json.loads(rule_matches_df.to_json(orient="index"))
+    return message

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,4 +6,5 @@ from icehockey_rules.app import app
 
 @pytest.fixture(scope="function")
 def app_test_client() -> TestClient:
+    assert True
     return TestClient(app=app, headers={})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,5 +6,4 @@ from icehockey_rules.app import app
 
 @pytest.fixture(scope="function")
 def app_test_client() -> TestClient:
-    assert True
     return TestClient(app=app, headers={})


### PR DESCRIPTION
* one_off_question_answer function now adds retrieved rules to message for downstream use (should have been commited in last PR but hacking on the fly leads to early PR merges...)
* Dockerfile no longer tries to copy python files in root directory that were moved in the last PR
* pre-commit testing skips tests that cost money